### PR TITLE
feat: add waitlist landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# ai-mvp-english
+# AI English Tutor Landing Page
+
+Demo landing page built with React, TypeScript, Tailwind CSS and shadcn-style components.
+
+## Development
+
+- Compile TypeScript: `tsc`
+- Open `index.html` in a modern browser.
+- Waitlist emails are stored in `localStorage` under `waitlist.emails`.
+
+Default admin passcode is `admin1234`.

--- a/dist/App.js
+++ b/dist/App.js
@@ -1,0 +1,112 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+import { useState, useEffect } from 'react';
+import { Input } from './components/ui/input';
+import { Button } from './components/ui/button';
+import { Checkbox } from './components/ui/checkbox';
+import { Label } from './components/ui/label';
+import { Dialog } from './components/ui/dialog';
+import { Toast } from './components/ui/toast';
+function getStoredEmails() {
+    try {
+        const raw = localStorage.getItem('waitlist.emails');
+        return raw ? JSON.parse(raw) : [];
+    }
+    catch {
+        return [];
+    }
+}
+function saveEmails(list) {
+    localStorage.setItem('waitlist.emails', JSON.stringify(list));
+}
+function AdminDashboard({ emails, setEmails, onClose }) {
+    const [query, setQuery] = useState('');
+    const filtered = emails.filter(e => e.email.includes(query));
+    const deleteOne = (email) => {
+        const next = emails.filter(e => e.email !== email);
+        setEmails(next);
+        saveEmails(next);
+    };
+    const deleteAll = () => {
+        setEmails([]);
+        saveEmails([]);
+    };
+    const exportCSV = () => {
+        const header = 'email,submittedAt\n';
+        const rows = emails.map(e => `${e.email},${e.submittedAt}`).join('\n');
+        const blob = new Blob([header + rows], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'waitlist.csv';
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+    return (_jsxs("div", { className: "p-4 max-w-3xl mx-auto", children: [_jsx("h2", { className: "text-2xl font-bold mb-4", children: "\uC218\uC9D1 \uC774\uBA54\uC77C \uBAA9\uB85D" }), _jsxs("div", { className: "flex items-center gap-2 mb-4", children: [_jsx(Input, { placeholder: "\uAC80\uC0C9", value: query, onChange: e => setQuery(e.target.value), className: "max-w-xs" }), _jsx(Button, { onClick: exportCSV, children: "CSV \uB0B4\uBCF4\uB0B4\uAE30" }), _jsx(Button, { onClick: deleteAll, className: "bg-red-600 hover:bg-red-700", children: "\uC804\uCCB4 \uC0AD\uC81C" }), _jsx(Button, { onClick: onClose, className: "ml-auto", children: "\uB2EB\uAE30" })] }), _jsx("div", { className: "overflow-x-auto", children: _jsxs("table", { className: "w-full text-sm", children: [_jsx("thead", { children: _jsxs("tr", { className: "border-b", children: [_jsx("th", { className: "p-2 text-left", children: "\uC774\uBA54\uC77C" }), _jsx("th", { className: "p-2 text-left", children: "\uC81C\uCD9C \uC2DC\uAC01" }), _jsx("th", { className: "p-2" })] }) }), _jsxs("tbody", { children: [filtered.map((item) => (_jsxs("tr", { className: "border-b last:border-0", children: [_jsx("td", { className: "p-2 break-all", children: item.email }), _jsx("td", { className: "p-2", children: new Date(item.submittedAt).toLocaleString() }), _jsx("td", { className: "p-2 text-right", children: _jsx(Button, { onClick: () => deleteOne(item.email), className: "bg-red-600 hover:bg-red-700", children: "\uC0AD\uC81C" }) })] }, item.email))), filtered.length === 0 && (_jsx("tr", { children: _jsx("td", { colSpan: 3, className: "p-4 text-center text-gray-500", children: "\uB370\uC774\uD130\uAC00 \uC5C6\uC2B5\uB2C8\uB2E4." }) }))] })] }) })] }));
+}
+export default function App() {
+    const [emails, setEmails] = useState(getStoredEmails());
+    const [email, setEmail] = useState('');
+    const [consent, setConsent] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [toast, setToast] = useState(null);
+    const [isAdmin, setIsAdmin] = useState(false);
+    const [passcodeOpen, setPasscodeOpen] = useState(false);
+    const [passcode, setPasscode] = useState('');
+    useEffect(() => {
+        const t = setTimeout(() => setToast(null), 3000);
+        return () => clearTimeout(t);
+    }, [toast]);
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        if (loading)
+            return;
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(email)) {
+            setToast({ message: '유효한 이메일을 입력하세요.', type: 'error' });
+            return;
+        }
+        if (!consent) {
+            setToast({ message: '개인정보 수집에 동의해야 합니다.', type: 'error' });
+            return;
+        }
+        if (emails.some(e => e.email === email)) {
+            setToast({ message: '이미 제출된 이메일입니다.', type: 'error' });
+            return;
+        }
+        setLoading(true);
+        const entry = { email, submittedAt: new Date().toISOString() };
+        const next = [entry, ...emails];
+        saveEmails(next);
+        setEmails(next);
+        setEmail('');
+        setConsent(false);
+        setLoading(false);
+        setToast({ message: '제출되었습니다!', type: 'success' });
+    };
+    const openAdmin = (e) => {
+        e.preventDefault();
+        if (passcode === 'admin1234') {
+            setIsAdmin(true);
+            setPasscodeOpen(false);
+            setPasscode('');
+        }
+        else {
+            setToast({ message: '패스코드가 올바르지 않습니다.', type: 'error' });
+        }
+    };
+    return (_jsxs("div", { className: "text-gray-900", children: [toast && _jsx(Toast, { message: toast.message, type: toast.type }), _jsx("button", { className: "fixed top-4 right-4 z-40 text-sm underline", onClick: () => setPasscodeOpen(true), children: "\uAD00\uB9AC\uC790 \uBAA8\uB4DC" }), _jsx(Dialog, { open: passcodeOpen, onClose: () => setPasscodeOpen(false), children: _jsxs("form", { onSubmit: openAdmin, className: "space-y-4", children: [_jsxs("div", { children: [_jsx(Label, { htmlFor: "pass", children: "\uD328\uC2A4\uCF54\uB4DC" }), _jsx(Input, { id: "pass", type: "password", value: passcode, onChange: e => setPasscode(e.target.value) })] }), _jsx(Button, { type: "submit", className: "w-full", children: "\uC785\uC7A5" })] }) }), isAdmin ? (_jsx(AdminDashboard, { emails: emails, setEmails: setEmails, onClose: () => setIsAdmin(false) })) : (_jsxs("main", { children: [_jsxs("section", { className: "min-h-screen flex flex-col items-center justify-center text-center px-4", children: [_jsx("h1", { className: "text-4xl font-bold mb-4", children: "AI \uD29C\uD130\uB85C \uBA74\uC811 \uC601\uC5B4\uB97C \uBE60\uB974\uAC8C \uC900\uBE44\uD558\uC138\uC694" }), _jsx("p", { className: "mb-6 text-lg", children: "\uCDE8\uC5C5 \uC900\uBE44 \uB300\uD559\uC0DD\uC744 \uC704\uD55C AI \uC601\uC5B4 \uD559\uC2B5 \uC11C\uBE44\uC2A4" }), _jsxs("form", { onSubmit: handleSubmit, className: "w-full max-w-md space-y-4", children: [_jsx(Input, { type: "email", placeholder: "\uC774\uBA54\uC77C \uC8FC\uC18C", value: email, onChange: e => setEmail(e.target.value), "aria-label": "\uC774\uBA54\uC77C \uC8FC\uC18C", required: true }), _jsxs("div", { className: "flex items-center space-x-2", children: [_jsx(Checkbox, { id: "consent", checked: consent, onChange: e => setConsent(e.target.checked), "aria-describedby": "consent-desc" }), _jsx(Label, { htmlFor: "consent", id: "consent-desc", children: "(\uD544\uC218) \uC774\uBA54\uC77C \uC218\uC9D1\uC5D0 \uB3D9\uC758\uD569\uB2C8\uB2E4" })] }), _jsx(Button, { type: "submit", disabled: loading, className: "w-full", children: loading ? '처리중...' : '대기 명단 신청' })] })] }), _jsx("section", { className: "py-16 bg-gray-50", children: _jsxs("div", { className: "max-w-4xl mx-auto px-4 text-center", children: [_jsx("h2", { className: "text-2xl font-bold mb-8", children: "\uBB38\uC81C / \uD574\uACB0 / \uAC00\uCE58 \uC81C\uC548" }), _jsx("div", { className: "grid grid-cols-1 md:grid-cols-3 gap-6", children: [
+                                        { title: '시간 부족', desc: '빠르게 준비해야 하지만 자료가 부족합니다.' },
+                                        { title: '맞춤 피드백', desc: 'AI가 개인 맞춤 피드백을 제공합니다.' },
+                                        { title: '언제 어디서나', desc: '모바일로도 학습이 가능합니다.' }
+                                    ].map(card => (_jsxs("div", { className: "p-4 border rounded-md bg-white", children: [_jsx("h3", { className: "font-semibold mb-2", children: card.title }), _jsx("p", { className: "text-sm text-gray-600", children: card.desc })] }, card.title))) })] }) }), _jsx("section", { className: "py-16", children: _jsxs("div", { className: "max-w-3xl mx-auto px-4 text-center", children: [_jsx("h2", { className: "text-2xl font-bold mb-8", children: "\uC791\uB3D9 \uBC29\uC2DD" }), _jsx("div", { className: "grid grid-cols-1 md:grid-cols-3 gap-6", children: [
+                                        { step: '1', desc: 'AI에게 목표를 알려주세요.' },
+                                        { step: '2', desc: '맞춤 커리큘럼을 받으세요.' },
+                                        { step: '3', desc: '실전 연습으로 준비를 마무리하세요.' }
+                                    ].map(s => (_jsxs("div", { className: "p-4 border rounded-md", children: [_jsx("div", { className: "text-3xl font-bold mb-2", children: s.step }), _jsx("p", { className: "text-sm text-gray-600", children: s.desc })] }, s.step))) })] }) }), _jsx("section", { className: "py-16 bg-gray-50", children: _jsxs("div", { className: "max-w-3xl mx-auto px-4 text-center", children: [_jsx("h2", { className: "text-2xl font-bold mb-8", children: "\uC0AC\uC6A9\uC790 \uD6C4\uAE30" }), _jsx("div", { className: "grid grid-cols-1 md:grid-cols-3 gap-6", children: Array.from({ length: 3 }).map((_, i) => (_jsx("div", { className: "p-4 border rounded-md bg-white text-sm text-gray-600", children: "\"\uB354\uBBF8 \uD6C4\uAE30\uAC00 \uB4E4\uC5B4\uAC08 \uC790\uB9AC\"" }, i))) })] }) }), _jsx("section", { className: "py-16", children: _jsxs("div", { className: "max-w-3xl mx-auto px-4", children: [_jsx("h2", { className: "text-2xl font-bold mb-8 text-center", children: "FAQ" }), _jsx("div", { className: "space-y-4", children: [
+                                        { q: '어떻게 이용하나요?', a: '이메일 등록 후 안내를 받아보세요.' },
+                                        { q: '비용은 얼마인가요?', a: '정식 출시 전에 공지됩니다.' },
+                                        { q: '데이터는 안전한가요?', a: '로컬에만 저장되며 언제든 삭제할 수 있습니다.' },
+                                        { q: '모바일도 지원하나요?', a: '네, 모바일 최적화가 되어 있습니다.' },
+                                        { q: '언제 출시되나요?', a: '곧 출시 예정입니다.' }
+                                    ].map(item => (_jsxs("div", { className: "border rounded-md p-4 bg-white", children: [_jsx("p", { className: "font-semibold", children: item.q }), _jsx("p", { className: "text-sm text-gray-600 mt-2", children: item.a })] }, item.q))) })] }) }), _jsxs("footer", { className: "py-8 bg-gray-100 text-center text-sm text-gray-600", children: [_jsx("p", { className: "mb-2", children: "\uAC1C\uC778\uC815\uBCF4\uB294 \uB370\uBAA8\uC6A9\uC73C\uB85C \uB85C\uCEEC\uC5D0\uB9CC \uC800\uC7A5\uB429\uB2C8\uB2E4." }), _jsx("p", { children: "\uBB38\uC758: support@example.com" })] })] }))] }));
+}

--- a/dist/components/ui/button.js
+++ b/dist/components/ui/button.js
@@ -1,0 +1,4 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+export function Button({ className = '', children, ...props }) {
+    return (_jsx("button", { className: `inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none bg-blue-600 text-white hover:bg-blue-700 h-10 px-4 py-2 ${className}`, ...props, children: children }));
+}

--- a/dist/components/ui/checkbox.js
+++ b/dist/components/ui/checkbox.js
@@ -1,0 +1,4 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import React from 'react';
+export const Checkbox = React.forwardRef(({ className = '', ...props }, ref) => (_jsx("input", { type: "checkbox", ref: ref, className: `h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-600 ${className}`, ...props })));
+Checkbox.displayName = 'Checkbox';

--- a/dist/components/ui/dialog.js
+++ b/dist/components/ui/dialog.js
@@ -1,0 +1,6 @@
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+export function Dialog({ open, onClose, children }) {
+    if (!open)
+        return null;
+    return (_jsx("div", { className: "fixed inset-0 z-50 flex items-center justify-center bg-black/50", role: "dialog", "aria-modal": "true", children: _jsxs("div", { className: "relative bg-white p-6 rounded-md shadow w-full max-w-sm", children: [_jsx("button", { "aria-label": "Close", className: "absolute top-2 right-2 text-gray-500 hover:text-gray-700", onClick: onClose, children: "\u2715" }), children] }) }));
+}

--- a/dist/components/ui/input.js
+++ b/dist/components/ui/input.js
@@ -1,0 +1,4 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import React from 'react';
+export const Input = React.forwardRef(({ className = '', ...props }, ref) => (_jsx("input", { ref: ref, className: `flex h-10 w-full rounded-md border border-gray-300 bg-transparent px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-600 ${className}`, ...props })));
+Input.displayName = 'Input';

--- a/dist/components/ui/label.js
+++ b/dist/components/ui/label.js
@@ -1,0 +1,4 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+export function Label({ className = '', children, ...props }) {
+    return (_jsx("label", { className: `text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 ${className}`, ...props, children: children }));
+}

--- a/dist/components/ui/toast.js
+++ b/dist/components/ui/toast.js
@@ -1,0 +1,4 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+export function Toast({ message, type }) {
+    return (_jsx("div", { role: "status", className: `fixed top-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded-md text-white shadow transition-all ${type === 'success' ? 'bg-green-600' : 'bg-red-600'}`, children: message }));
+}

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,8 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import { createRoot } from 'react-dom/client';
+import App from './App';
+const container = document.getElementById('root');
+if (container) {
+    const root = createRoot(container);
+    root.render(_jsx(App, {}));
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!--
+README
+- 환경 셋업: 필요 시 TypeScript 컴파일 `tsc` (전역 설치됨)
+- 실행: `index.html`을 브라우저로 열기
+- 관리자 패스코드 변경: `src/App.tsx`의 `passcode === 'admin1234'` 부분 수정
+- 데이터 저장소 스위칭: `getStoredEmails`/`saveEmails` 함수 부분을 서버 연동 등으로 교체
+-->
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI 영어 튜터</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.sh/react@18",
+          "react-dom/client": "https://esm.sh/react-dom@18/client"
+        }
+      }
+    </script>
+  </head>
+  <body class="min-h-screen">
+    <div id="root"></div>
+    <script type="module" src="./dist/main.js"></script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,285 @@
+import React, { useState, useEffect } from 'react';
+import { Input } from './components/ui/input';
+import { Button } from './components/ui/button';
+import { Checkbox } from './components/ui/checkbox';
+import { Label } from './components/ui/label';
+import { Dialog } from './components/ui/dialog';
+import { Toast } from './components/ui/toast';
+
+interface WaitlistEntry {
+  email: string;
+  submittedAt: string;
+}
+
+function getStoredEmails(): WaitlistEntry[] {
+  try {
+    const raw = localStorage.getItem('waitlist.emails');
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveEmails(list: WaitlistEntry[]) {
+  localStorage.setItem('waitlist.emails', JSON.stringify(list));
+}
+
+function AdminDashboard({ emails, setEmails, onClose }: { emails: WaitlistEntry[]; setEmails: (v: WaitlistEntry[]) => void; onClose: () => void; }) {
+  const [query, setQuery] = useState('');
+  const filtered = emails.filter(e => e.email.includes(query));
+
+  const deleteOne = (email: string) => {
+    const next = emails.filter(e => e.email !== email);
+    setEmails(next);
+    saveEmails(next);
+  };
+
+  const deleteAll = () => {
+    setEmails([]);
+    saveEmails([]);
+  };
+
+  const exportCSV = () => {
+    const header = 'email,submittedAt\n';
+    const rows = emails.map(e => `${e.email},${e.submittedAt}`).join('\n');
+    const blob = new Blob([header + rows], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'waitlist.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="p-4 max-w-3xl mx-auto">
+      <h2 className="text-2xl font-bold mb-4">수집 이메일 목록</h2>
+      <div className="flex items-center gap-2 mb-4">
+        <Input
+          placeholder="검색"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          className="max-w-xs"
+        />
+        <Button onClick={exportCSV}>CSV 내보내기</Button>
+        <Button onClick={deleteAll} className="bg-red-600 hover:bg-red-700">전체 삭제</Button>
+        <Button onClick={onClose} className="ml-auto">닫기</Button>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2 text-left">이메일</th>
+              <th className="p-2 text-left">제출 시각</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((item) => (
+              <tr key={item.email} className="border-b last:border-0">
+                <td className="p-2 break-all">{item.email}</td>
+                <td className="p-2">{new Date(item.submittedAt).toLocaleString()}</td>
+                <td className="p-2 text-right">
+                  <Button
+                    onClick={() => deleteOne(item.email)}
+                    className="bg-red-600 hover:bg-red-700"
+                  >
+                    삭제
+                  </Button>
+                </td>
+              </tr>
+            ))}
+            {filtered.length === 0 && (
+              <tr>
+                <td colSpan={3} className="p-4 text-center text-gray-500">데이터가 없습니다.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default function App() {
+  const [emails, setEmails] = useState(getStoredEmails());
+  const [email, setEmail] = useState('');
+  const [consent, setConsent] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [toast, setToast] = useState(null as any);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [passcodeOpen, setPasscodeOpen] = useState(false);
+  const [passcode, setPasscode] = useState('');
+
+  useEffect(() => {
+    const t = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  const handleSubmit = (e: any) => {
+    e.preventDefault();
+    if (loading) return;
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setToast({ message: '유효한 이메일을 입력하세요.', type: 'error' });
+      return;
+    }
+    if (!consent) {
+      setToast({ message: '개인정보 수집에 동의해야 합니다.', type: 'error' });
+      return;
+    }
+    if (emails.some(e => e.email === email)) {
+      setToast({ message: '이미 제출된 이메일입니다.', type: 'error' });
+      return;
+    }
+    setLoading(true);
+    const entry = { email, submittedAt: new Date().toISOString() };
+    const next = [entry, ...emails];
+    saveEmails(next);
+    setEmails(next);
+    setEmail('');
+    setConsent(false);
+    setLoading(false);
+    setToast({ message: '제출되었습니다!', type: 'success' });
+  };
+
+  const openAdmin = (e: any) => {
+    e.preventDefault();
+    if (passcode === 'admin1234') {
+      setIsAdmin(true);
+      setPasscodeOpen(false);
+      setPasscode('');
+    } else {
+      setToast({ message: '패스코드가 올바르지 않습니다.', type: 'error' });
+    }
+  };
+
+  return (
+    <div className="text-gray-900">
+      {toast && <Toast message={toast.message} type={toast.type} />}
+      <button
+        className="fixed top-4 right-4 z-40 text-sm underline"
+        onClick={() => setPasscodeOpen(true)}
+      >
+        관리자 모드
+      </button>
+      <Dialog open={passcodeOpen} onClose={() => setPasscodeOpen(false)}>
+        <form onSubmit={openAdmin} className="space-y-4">
+          <div>
+            <Label htmlFor="pass">패스코드</Label>
+            <Input
+              id="pass"
+              type="password"
+              value={passcode}
+              onChange={e => setPasscode(e.target.value)}
+            />
+          </div>
+          <Button type="submit" className="w-full">입장</Button>
+        </form>
+      </Dialog>
+      {isAdmin ? (
+        <AdminDashboard emails={emails} setEmails={setEmails} onClose={() => setIsAdmin(false)} />
+      ) : (
+        <main>
+          <section className="min-h-screen flex flex-col items-center justify-center text-center px-4">
+            <h1 className="text-4xl font-bold mb-4">AI 튜터로 면접 영어를 빠르게 준비하세요</h1>
+            <p className="mb-6 text-lg">취업 준비 대학생을 위한 AI 영어 학습 서비스</p>
+            <form onSubmit={handleSubmit} className="w-full max-w-md space-y-4">
+              <Input
+                type="email"
+                placeholder="이메일 주소"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                aria-label="이메일 주소"
+                required
+              />
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="consent"
+                  checked={consent}
+                  onChange={e => setConsent(e.target.checked)}
+                  aria-describedby="consent-desc"
+                />
+                <Label htmlFor="consent" id="consent-desc">
+                  (필수) 이메일 수집에 동의합니다
+                </Label>
+              </div>
+              <Button type="submit" disabled={loading} className="w-full">
+                {loading ? '처리중...' : '대기 명단 신청'}
+              </Button>
+            </form>
+          </section>
+          <section className="py-16 bg-gray-50">
+            <div className="max-w-4xl mx-auto px-4 text-center">
+              <h2 className="text-2xl font-bold mb-8">문제 / 해결 / 가치 제안</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                {[
+                  { title: '시간 부족', desc: '빠르게 준비해야 하지만 자료가 부족합니다.' },
+                  { title: '맞춤 피드백', desc: 'AI가 개인 맞춤 피드백을 제공합니다.' },
+                  { title: '언제 어디서나', desc: '모바일로도 학습이 가능합니다.' }
+                ].map(card => (
+                  <div key={card.title} className="p-4 border rounded-md bg-white">
+                    <h3 className="font-semibold mb-2">{card.title}</h3>
+                    <p className="text-sm text-gray-600">{card.desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+          <section className="py-16">
+            <div className="max-w-3xl mx-auto px-4 text-center">
+              <h2 className="text-2xl font-bold mb-8">작동 방식</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                {[
+                  { step: '1', desc: 'AI에게 목표를 알려주세요.' },
+                  { step: '2', desc: '맞춤 커리큘럼을 받으세요.' },
+                  { step: '3', desc: '실전 연습으로 준비를 마무리하세요.' }
+                ].map(s => (
+                  <div key={s.step} className="p-4 border rounded-md">
+                    <div className="text-3xl font-bold mb-2">{s.step}</div>
+                    <p className="text-sm text-gray-600">{s.desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+          <section className="py-16 bg-gray-50">
+            <div className="max-w-3xl mx-auto px-4 text-center">
+              <h2 className="text-2xl font-bold mb-8">사용자 후기</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="p-4 border rounded-md bg-white text-sm text-gray-600">
+                    "더미 후기가 들어갈 자리"
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+          <section className="py-16">
+            <div className="max-w-3xl mx-auto px-4">
+              <h2 className="text-2xl font-bold mb-8 text-center">FAQ</h2>
+              <div className="space-y-4">
+                {[
+                  { q: '어떻게 이용하나요?', a: '이메일 등록 후 안내를 받아보세요.' },
+                  { q: '비용은 얼마인가요?', a: '정식 출시 전에 공지됩니다.' },
+                  { q: '데이터는 안전한가요?', a: '로컬에만 저장되며 언제든 삭제할 수 있습니다.' },
+                  { q: '모바일도 지원하나요?', a: '네, 모바일 최적화가 되어 있습니다.' },
+                  { q: '언제 출시되나요?', a: '곧 출시 예정입니다.' }
+                ].map(item => (
+                  <div key={item.q} className="border rounded-md p-4 bg-white">
+                    <p className="font-semibold">{item.q}</p>
+                    <p className="text-sm text-gray-600 mt-2">{item.a}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+          <footer className="py-8 bg-gray-100 text-center text-sm text-gray-600">
+            <p className="mb-2">개인정보는 데모용으로 로컬에만 저장됩니다.</p>
+            <p>문의: support@example.com</p>
+          </footer>
+        </main>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export interface ButtonProps {
+  className?: string;
+  children?: any;
+  [key: string]: any;
+}
+
+export function Button({ className = '', children, ...props }: ButtonProps) {
+  return (
+    <button
+      className={`inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none bg-blue-600 text-white hover:bg-blue-700 h-10 px-4 py-2 ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export interface CheckboxProps {
+  className?: string;
+  [key: string]: any;
+}
+
+export const Checkbox = React.forwardRef(
+  ({ className = '', ...props }: CheckboxProps, ref: any) => (
+    <input
+      type="checkbox"
+      ref={ref}
+      className={`h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-600 ${className}`}
+      {...props}
+    />
+  )
+);
+Checkbox.displayName = 'Checkbox';

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface DialogProps {
+  open: boolean;
+  onClose: () => void;
+  children: any;
+}
+
+export function Dialog({ open, onClose, children }: DialogProps) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true">
+      <div className="relative bg-white p-6 rounded-md shadow w-full max-w-sm">
+        <button
+          aria-label="Close"
+          className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export interface InputProps {
+  className?: string;
+  [key: string]: any;
+}
+
+export const Input = React.forwardRef((
+  { className = '', ...props }: InputProps,
+  ref: any
+) => (
+  <input
+    ref={ref}
+    className={`flex h-10 w-full rounded-md border border-gray-300 bg-transparent px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-600 ${className}`}
+    {...props}
+  />
+));
+Input.displayName = 'Input';

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export interface LabelProps {
+  className?: string;
+  children?: any;
+  htmlFor?: string;
+  id?: string;
+  [key: string]: any;
+}
+
+export function Label({ className = '', children, ...props }: LabelProps) {
+  return (
+    <label
+      className={`text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 ${className}`}
+      {...props}
+    >
+      {children}
+    </label>
+  );
+}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface ToastProps {
+  message: string;
+  type: 'success' | 'error';
+}
+
+export function Toast({ message, type }: ToastProps) {
+  return (
+    <div
+      role="status"
+      className={`fixed top-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded-md text-white shadow transition-all ${
+        type === 'success' ? 'bg-green-600' : 'bg-red-600'
+      }`}
+    >
+      {message}
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/src/react.d.ts
+++ b/src/react.d.ts
@@ -1,0 +1,26 @@
+declare module 'react' {
+  export const useState: any;
+  export const useEffect: any;
+  export const useRef: any;
+  export const useMemo: any;
+  export const useCallback: any;
+  export const Fragment: any;
+  const React: any;
+  export default React;
+}
+
+declare module 'react-dom/client' {
+  export function createRoot(container: any): { render(el: any): void };
+}
+
+declare module 'react/jsx-runtime' {
+  export const jsx: any;
+  export const jsxs: any;
+  export const Fragment: any;
+}
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    [elemName: string]: any;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": false,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- build minimal landing page with waitlist signup and admin dashboard
- store emails in localStorage with basic validation and CSV export
- include Tailwind-based shadcn-style UI components and admin passcode modal

## Testing
- `tsc`


------
https://chatgpt.com/codex/tasks/task_e_689d150c6ab8832cb3b23d1db150a374